### PR TITLE
Add automated release workflow for plugin distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
 
 jobs:
   shellcheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 1.2.0)'
+        required: true
+        type: string
+
+jobs:
+  bump-and-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: '$VERSION'"
+            echo "Expected semver format: X.Y.Z (e.g. 1.2.0)"
+            exit 1
+          fi
+      - name: Check tag does not exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag v$VERSION already exists"
+            exit 1
+          fi
+      - name: Bump version in plugin
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          OLD='\[Info("TakaroConnector", "Takaro", "[^"]*")\]'
+          NEW="[Info(\"TakaroConnector\", \"Takaro\", \"$VERSION\")]"
+          sed -i "s/$OLD/$NEW/" plugin/TakaroConnector.cs
+          grep -q "\[Info(\"TakaroConnector\", \"Takaro\", \"$VERSION\")\]" \
+            plugin/TakaroConnector.cs || {
+            echo "::error::Failed to update version"
+            exit 1
+          }
+      - name: Upload bumped plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-source
+          path: plugin/TakaroConnector.cs
+
+  ci:
+    needs: [bump-and-validate]
+    uses: ./.github/workflows/ci.yml
+
+  release:
+    needs: [ci]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download bumped plugin
+        uses: actions/download-artifact@v4
+        with:
+          name: plugin-source
+          path: plugin/
+      - name: Commit, tag, and release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "github-actions[bot]@users.noreply.github.com"
+          git add plugin/TakaroConnector.cs
+          git commit -m "release: v$VERSION"
+          git tag "v$VERSION"
+          git push origin HEAD "v$VERSION"
+          gh release create "v$VERSION" \
+            plugin/TakaroConnector.cs \
+            --title "TakaroConnector v$VERSION" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch`-triggered release workflow that automates the full release cycle: version bump in `TakaroConnector.cs`, CI validation, git tag, and GitHub Release creation
- Makes the existing CI workflow reusable via `workflow_call` so release can invoke it

## How it works
1. Go to Actions → "Release" → "Run workflow"
2. Enter version (e.g. `1.2.0`)
3. Workflow bumps the `[Info]` attribute in the plugin, uploads as artifact
4. CI runs compile-check on the bumped code
5. Only after CI passes: commits, tags, pushes, and creates a GitHub Release with `TakaroConnector.cs` attached

Users download the plugin from the GitHub Releases page and drop it into their Carbon `plugins/` folder.

## Safety features
- Semver format validation (`X.Y.Z`) before any mutations
- Tag existence check to prevent duplicates
- CI validates before commit/tag are pushed (no broken releases on main)
- grep verification after sed to ensure version was actually updated

## Test plan
- [ ] Verify YAML is valid (`yamllint .github/workflows/*.yml`)
- [ ] Trigger workflow with valid version (e.g. `1.0.0`)
- [ ] Trigger workflow with invalid version (e.g. `bad`) — should fail at validation
- [ ] Trigger workflow with duplicate version — should fail at tag check
- [ ] Verify GitHub Release page has `TakaroConnector.cs` as downloadable asset